### PR TITLE
Update your_workflow_definition_dacx.go

### DIFF
--- a/yourapp/your_workflow_definition_dacx.go
+++ b/yourapp/your_workflow_definition_dacx.go
@@ -71,7 +71,7 @@ func YourWorkflowDefinition(ctx workflow.Context, param YourWorkflowParam) (*You
 	// Use a nil struct pointer to call Activities that are part of a struct.
 	var a *YourActivityObject
 	// Execute the Activity and wait for the result.
-	var activityResult *YourActivityResultObject
+	var activityResult YourActivityResultObject
 	/*
 	   	The Activity function name can be provided as a variable object (no quotations) or as a string.
 	       The benefit of passing the actual function object is that the framework can validate the parameters against the Activity Definition.


### PR DESCRIPTION
## What does this PR do?
The documentation has an (typo) issue that `activityResult` should be a `YourActivityResultObject` type instead of the pointer. Otherwise, following this documentation will cause issues like
```
failed executing YourActivityDefinition activity: payload item 0: unable to decode: json: Unmarshal(nil *foo.activityResult)",
```

The right way in another example here https://learn.temporal.io/getting_started/go/first_program_in_go/ is also **not** declaring the var a pointer.

```
var withdrawOutput string

withdrawErr := workflow.ExecuteActivity(ctx, Withdraw, input).Get(ctx, &withdrawOutput)
```

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
